### PR TITLE
version hash updated

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,8 +1,8 @@
 {
  "minimum_version": "1.0.50",
- "unknown25": 7363665268261374000,
- "seed1": 1634035250,
- "version_number": 3500,
+ "unknown25": -8408506833887075802,
+ "seed1": 0,
+ "version_number": 4300,
  "latest_release": {
    "version": "1.0.29",
    "setup_file": "https://github.com/ST-Apps/PoGo-UWP/releases/download/v1.1.0-RC2/PokemonGo-UWP_1.0.29.0_{arch}.appxbundle",

--- a/version.json
+++ b/version.json
@@ -1,7 +1,7 @@
 {
  "minimum_version": "1.0.50",
  "unknown25": -8408506833887075802,
- "seed1": 0,
+ "seed1": 1629781951,
  "version_number": 4300,
  "latest_release": {
    "version": "1.0.29",


### PR DESCRIPTION
Closes issues
-------------
None

Changes
-------

Change details
--------------
updated version_hash to 0.43.4, seed1 is not used anymore (it is more complex now, so maybe we will transfer it here later) 


Other informations
------------------


