### PR TITLE
Version 0.47 forced

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
- "minimum_version": "1.0.52",
+ "minimum_version": "1.0.53",
  "unknown25": -1553869577012279119,
  "seed1": 1189692920,
  "version_number": 4500,


### PR DESCRIPTION
... and hash function is not fixed yet, so I must forbid last version